### PR TITLE
Add `esp_vfs_console` option for esp32 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,5 +27,5 @@ idf_component_register(SRCS "commands.c"
                             "linenoise/linenoise.c"
                             ${argtable_srcs}
                     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
-                    REQUIRES vfs
+                    REQUIRES vfs esp_vfs_console
                     PRIV_REQUIRES driver)


### PR DESCRIPTION
This option is required to compile can_wizard for ESP32 without affecting the ESP32-C3 compilation.
https://github.com/okhsunrog/can_wizard/pull/3 requires this to function properly.